### PR TITLE
Simplify Deploy with Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,9 +28,6 @@ bookmark-*.tar
 # Ignore assets that are produced by build tools.
 /priv/static/assets/
 
-# Ignore archives
-/priv/static/archive
-
 # Ignore digested assets cache.
 /priv/static/cache_manifest.json
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-include .env
 export
 
 default: help
@@ -32,10 +31,10 @@ clean: # Terminates the execution of all containers + delete volumes
 
 .PHONY: push-image
 push-image: # Push image to registry
-	docker tag bookmark:latest $(DOCKER_REGISTRY)/bookmark:latest
-	docker push $(DOCKER_REGISTRY)/bookmark:latest
+	docker tag bookmark:latest bookmarkorg/bookmark:latest
+	docker push bookmarkorg/bookmark:latest
 
 .PHONY: pull-images
 pull-images: # Pull images from registry
-	docker pull $(DOCKER_REGISTRY)/bookmark:latest
-	docker pull $(DOCKER_REGISTRY)/archivebox-server:latest
+	docker pull bookmarkorg/bookmark:latest
+	docker pull bookmarkorg/archivebox-server:latest

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Bookmark
 
-This is the repo containing the [bookmark.org](https://bookmark.org/) code.
+This repository contains the code for [bookmark.org](https://bookmark.org/), an online service that allows users to archive and organize important web links.
 
 ## Setup
 
-1. Install [docker](https://docs.docker.com/engine/install/)
-2. Create the archive folder with `mkdir priv/static/archive/` inside this repository.
-3. Optional: Login to the Docker registry (required for Docker image pushes)
+1. Install [Docker](https://docs.docker.com/engine/install/). Don't forget to perform the [Docker post-installation](https://docs.docker.com/engine/install/linux-postinstall/).
+
+2. Optional: Login to the Docker registry (only required for Docker image pushes)
 
 ```
 $ docker login -u bookmarkorg -p <registry-password>
@@ -14,20 +14,19 @@ $ docker login -u bookmarkorg -p <registry-password>
 
 ## Basic Commands: Development
 
-Run app:
+Run the app:
 
 ```
-# Install elixir dependencies
+# Install Elixir dependencies
 mix deps.get
 
-# Run the Elixir app locally + DB and a Archivebox server in containers
+# Run the Elixir app locally + DB and an Archivebox server in containers
 make dev
 ```
 
 Now you can visit [`localhost:4000`](http://localhost:4000) 
 
-
-Stop app:
+Stop the app:
 
 ```
 make stop # Terminates the execution of all containers
@@ -41,7 +40,7 @@ make push-images
 
 ## Basic Commands: Production
 
-1. Download latest tagged image from Docker registry
+1. Download the latest tagged image from the Docker registry
 
 ```
 make pull-images
@@ -53,7 +52,7 @@ make pull-images
 make stop
 ```
 
-3. Run docker project
+3. Run the Docker project
 
 ```
 make prod
@@ -64,8 +63,8 @@ Now you can visit [`localhost:4000`](http://localhost:4000)
 
 ## Clean containers
 
-* After using the containers, you can destroy them with their volumes using `make clean`
+After using the containers, you can destroy them along with their volumes (which contain the archives) using `make clean`.
 
 ## Available tasks
 
-You can see available tasks (build, dev, prod, etc) and what they do with `make`
+You can see available tasks (build, dev, prod, etc.) and what they do with `make`.

--- a/README.md
+++ b/README.md
@@ -6,13 +6,7 @@ This is the repo containing the [bookmark.org](https://bookmark.org/) code.
 
 1. Install [docker](https://docs.docker.com/engine/install/)
 2. Create the archive folder with `mkdir priv/static/archive/` inside this repository.
-3. In the root of the project `/bookmark`, create a `.env` file with the following content:
-
-```
-DOCKER_REGISTRY=bookmarkorg
-```
-
-4. Optional: Login to the Docker registry (required for Docker image pushes)
+3. Optional: Login to the Docker registry (required for Docker image pushes)
 
 ```
 $ docker login -u bookmarkorg -p <registry-password>

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -13,7 +13,7 @@ services:
       - db:/var/lib/postgresql/data
 
   archivebox:
-    image: ${DOCKER_REGISTRY}/archivebox-server:latest
+    image: bookmarkorg/archivebox-server:latest
     ports:
         - '5001:5000'
     # TODO: Archivebox Server must take environment variables to enable these properties

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   bookmark:
-    image: ${DOCKER_REGISTRY}/bookmark:latest
+    image: bookmarkorg/bookmark:latest
     container_name: bookmark-app
     restart: on-failure
     environment:
@@ -29,7 +29,7 @@ services:
       - db:/var/lib/postgresql/data
 
   archivebox:
-    image: ${DOCKER_REGISTRY}/archivebox-server:latest
+    image: bookmarkorg/archivebox-server:latest
     ports:
         - '5001:5000'
     # TODO: Archivebox Server must take environment variables to enable these properties

--- a/priv/static/archive/.gitignore
+++ b/priv/static/archive/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
Now you can deploy the entire app(with DB and Archviebox Server) with fewer steps, only downloading docker and then executing `make dev` or `make prod`