### PR TITLE
Add configurable delay to bulk archive process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,8 @@ prod: # Run bookmark dockerized in prod mode. Dockerized Database and Archivebox
 dev: # Run bookmark locally in dev mode. Dockerized Database and ArchiveboxServer
 	OPENAI_API_KEY=$(OPENAI_API_KEY)
 	export OPENAI_API_KEY
+	BOOKMARK_ARCHIVE_DELAY=$(BOOKMARK_ARCHIVE_DELAY)
+	export BOOKMARK_ARCHIVE_DELAY
 	docker compose -f docker-compose-dev.yml up -d
 	BOOKMARK_ARCHIVEBOX_URL=http://localhost:5001/add \
 	  BOOKMARK_NOSTR_CLIENT_URL=http://localhost:5005/links \

--- a/README.md
+++ b/README.md
@@ -6,10 +6,12 @@ This repository contains the code for [bookmark.org](https://bookmark.org/), an 
 
 1. Install [Docker](https://docs.docker.com/engine/install/). Don't forget to perform the [Docker post-installation](https://docs.docker.com/engine/install/linux-postinstall/).
 
-2. Optional: Create the following `.env` file in the root folder of this project (only required for archive summary generated with AI)
+2. Optional: Create the following `.env` file in the root folder of this project (only required for archive summary generated with AI and custom delay in bulk archiving)
 
 ```
 OPENAI_API_KEY=<api-key>
+# Expressed in milliseconds
+BOOKMARK_ARCHIVE_DELAY=1000
 ```
 
 3. Optional: Login to the Docker registry (only required for Docker image pushes)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     restart: on-failure
     environment:
       OPENAI_API_KEY: ${OPENAI_API_KEY}
+      BOOKMARK_ARCHIVE_DELAY: ${BOOKMARK_ARCHIVE_DELAY}
       MIX_ENV: prod
     depends_on:
       - bookmark-db


### PR DESCRIPTION
Now the delay is configurable adding this line to the `.env` file

```
# Expressed in milliseconds
BOOKMARK_ARCHIVE_DELAY=1000
```